### PR TITLE
Light cache class seems to be unnecessary 108

### DIFF
--- a/src/Liquid.OnAzure/Cache/AzureRedis.cs
+++ b/src/Liquid.OnAzure/Cache/AzureRedis.cs
@@ -1,16 +1,18 @@
-﻿using Liquid.Runtime;
+﻿using Liquid.Interfaces;
 using Liquid.Runtime.Configuration.Base;
+using Liquid.Runtime.Utils;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Redis;
 using System;
 using System.Threading.Tasks;
+
 
 namespace Liquid.OnAzure
 {
     /// <summary>
     ///  Include support of AzureRedis, that processing data included on Configuration file.
     /// </summary>
-    public class AzureRedis : LightCache
+    public class AzureRedis : ILightCache
     {
         private AzureRedisConfiguration config;
         private RedisCache _redisClient = null;
@@ -18,7 +20,7 @@ namespace Liquid.OnAzure
         /// <summary>
         /// Initialize support of Cache and read file config
         /// </summary>
-        public override void Initialize()
+        public void Initialize()
         {
             config = LightConfigurator.Config<AzureRedisConfiguration>("AzureRedis");
             _redisClient = new RedisCache(new RedisCacheOptions()
@@ -39,10 +41,10 @@ namespace Liquid.OnAzure
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="key">Key of object</param>
         /// <returns>object</returns>
-        public override T Get<T>(string key)
+        public T Get<T>(string key)
         {
             var data = _redisClient.Get(key);
-            return FromByteArray<T>(data);
+            return CollectionTools.FromByteArray<T>(data);
         }
         /// <summary>
         /// Get Key Async on the Azure Redis server cache
@@ -50,16 +52,16 @@ namespace Liquid.OnAzure
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="key">Key of object</param>
         /// <returns>Task with object</returns>
-        public override async Task<T> GetAsync<T>(string key)
+        public async Task<T> GetAsync<T>(string key)
         {
             var data = await _redisClient.GetAsync(key);
-            return FromByteArray<T>(data);
+            return CollectionTools.FromByteArray<T>(data);
         }
         /// <summary>
         /// Refresh key get on the Azure Redis server cache
         /// </summary>
         /// <param name="key">Key of object</param>
-        public override void Refresh(string key)
+        public void Refresh(string key)
         {
             _redisClient.Refresh(key);
         }
@@ -68,7 +70,7 @@ namespace Liquid.OnAzure
         /// </summary>
         /// <param name="key">Key of object</param>
         /// <returns>Task</returns>
-        public override async Task RefreshAsync(string key)
+        public async Task RefreshAsync(string key)
         {
             await _redisClient.RefreshAsync(key);
         }
@@ -76,7 +78,7 @@ namespace Liquid.OnAzure
         ///  Remove key on the Azure Redis server cache
         /// </summary>
         /// <param name="key">Key of object</param>
-        public override void Remove(string key)
+        public void Remove(string key)
         {
             _redisClient.Remove(key);
         }
@@ -85,7 +87,7 @@ namespace Liquid.OnAzure
         /// </summary>
         /// <param name="key">Key of object</param>
         /// <returns>Task</returns>
-        public override Task RemoveAsync(string key)
+        public Task RemoveAsync(string key)
         {
             return _redisClient.RemoveAsync(key);
         }
@@ -95,9 +97,9 @@ namespace Liquid.OnAzure
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="key">Key of object</param>
         /// <returns>object</returns>
-        public override void Set<T>(string key, T value)
+        public void Set<T>(string key, T value)
         {
-            _redisClient.Set(key, ToByteArray(value), _options);
+            _redisClient.Set(key, CollectionTools.ToByteArray(value), _options);
         }
         /// <summary>
         /// Set Key and value Async on the Azure Redis server cache
@@ -105,9 +107,12 @@ namespace Liquid.OnAzure
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="key">Key of object</param>
         /// <returns>Task with object</returns>
-        public override async Task SetAsync<T>(string key, T value)
+        public async Task SetAsync<T>(string key, T value)
         {
-            await _redisClient.SetAsync(key, ToByteArray(value), _options);
+            await _redisClient.SetAsync(key, CollectionTools.ToByteArray(value), _options);
         }
+
+        
+
     }
 }

--- a/src/Liquid.OnPre/Cache/MemoryCache.cs
+++ b/src/Liquid.OnPre/Cache/MemoryCache.cs
@@ -3,13 +3,14 @@ using System;
 using System.Threading.Tasks;
 using System.Runtime.Caching;
 using Liquid.Runtime.Configuration.Base;
+using Liquid.Interfaces;
 
 namespace Liquid.OnWindowsClient
 {
     /// <summary>
     ///  Include support of MemoryCache, that processing data included on Configuration file.
     /// </summary>
-    public class MemoryCache : LightCache
+    public class MemoryCache : ILightCache
     {
         /// <summary>
         /// Cache of memory
@@ -22,7 +23,7 @@ namespace Liquid.OnWindowsClient
         /// <summary>
         /// Initialize support of Cache and read file config
         /// </summary>
-        public override void Initialize()
+        public void Initialize()
         {
             config = LightConfigurator.Config<MemoryCacheConfiguration>("MemoryCache");
             options = new CacheItemPolicy()
@@ -37,7 +38,7 @@ namespace Liquid.OnWindowsClient
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="key">Key of object</param>
         /// <returns>object</returns>
-        public override T Get<T>(string key)
+        public T Get<T>(string key)
         {
             var data = (T)Cache.Get(key);
             return data;
@@ -48,7 +49,7 @@ namespace Liquid.OnWindowsClient
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="key">Key of object</param>
         /// <returns>Task with object</returns>
-        public override async Task<T> GetAsync<T>(string key)
+        public async Task<T> GetAsync<T>(string key)
         {
             var data = (T)Cache.Get(key);
             return await Task.FromResult<T>(data);
@@ -57,7 +58,7 @@ namespace Liquid.OnWindowsClient
         /// Refresh key get on the MemoryCache server cache
         /// </summary>
         /// <param name="key">Key of object</param>
-        public override void Refresh(string key)
+        public void Refresh(string key)
         {
             throw new NotImplementedException();
         }
@@ -66,7 +67,7 @@ namespace Liquid.OnWindowsClient
         /// </summary>
         /// <param name="key">Key of object</param>
         /// <returns>Task</returns>
-        public override async Task RefreshAsync(string key)
+        public async Task RefreshAsync(string key)
         {
             throw new NotImplementedException();
         }
@@ -74,7 +75,7 @@ namespace Liquid.OnWindowsClient
         ///  Remove key on the MemoryCache server cache
         /// </summary>
         /// <param name="key">Key of object</param>
-        public override void Remove(string key)
+        public void Remove(string key)
         {
             Cache.Remove(key);
         }
@@ -83,7 +84,7 @@ namespace Liquid.OnWindowsClient
         /// </summary>
         /// <param name="key">Key of object</param>
         /// <returns>Task</returns>
-        public override Task RemoveAsync(string key)
+        public  Task RemoveAsync(string key)
         {
             Cache.Remove(key);
             return Task.FromResult(true);
@@ -94,7 +95,7 @@ namespace Liquid.OnWindowsClient
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="key">Key of object</param>
         /// <returns>object</returns>
-        public override void Set<T>(string key, T value)
+        public void Set<T>(string key, T value)
         {
             Cache.Add(key, value, options);
         }
@@ -104,7 +105,7 @@ namespace Liquid.OnWindowsClient
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="key">Key of object</param>
         /// <returns>Task with object</returns>
-        public override async Task SetAsync<T>(string key, T value)
+        public async Task SetAsync<T>(string key, T value)
         {
             Cache.Add(key, value, options);
         }

--- a/src/Liquid.Runtime/Liquid.Runtime.csproj
+++ b/src/Liquid.Runtime/Liquid.Runtime.csproj
@@ -16,6 +16,9 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="NewFile1.txt" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.4.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.7.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="1.1.1" />

--- a/src/Liquid.Runtime/Utils/CollectionTools.cs
+++ b/src/Liquid.Runtime/Utils/CollectionTools.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using System.Runtime.Serialization;
+
+
+namespace Liquid.Runtime.Utils
+{
+    public static class CollectionTools
+    {
+        /// <summary>
+        /// Convert object to ByteArray
+        /// </summary>
+        /// <typeparam name="T">Type of object</typeparam>
+        /// <param name="obj">object</param>
+        /// <returns>Array of byte</returns>
+        public static byte[] ToByteArray(object obj)
+        {
+            using (var m = new MemoryStream())
+            {
+                var ser = new DataContractSerializer(obj.GetType());
+                ser.WriteObject(m, obj);
+                return m.ToArray();
+            }
+        }
+        /// <summary>
+        /// Convert Array of byte to object
+        /// </summary>
+        /// <typeparam name="T">Type of object</typeparam>
+        /// <param name="data">Array of byte</param>
+        /// <returns>object</returns>
+        public static T FromByteArray<T>(byte[] data)
+        {
+            if (data != null)
+            {
+                using (var m = new MemoryStream(data))
+                {
+                    var ser = new DataContractSerializer(typeof(T));
+                    return (T)ser.ReadObject(m);
+                }
+            }
+            else
+            {
+                return default(T);
+            }
+        }
+    }
+}

--- a/test/Liquid.Runtime.Tests/AzureRedisTest.cs
+++ b/test/Liquid.Runtime.Tests/AzureRedisTest.cs
@@ -1,0 +1,79 @@
+﻿using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using Liquid.Interfaces;
+using Liquid.OnAzure;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Liquid.Runtime.Tests
+{
+    public class AzureRedisTest : IDisposable
+    {
+        private const string ContentType = "text/plain";
+        private const string DefaultConnectionString = "UseDevelopmentStorage=true";
+        private const string DefaultContainerName = "removecontainer";
+        private static readonly IFixture _fixture = new Fixture().Customize(new AutoNSubstituteCustomization());
+
+        private static readonly ILightCache _fakeLightCache = Substitute.For<ILightCache>();
+
+        private readonly string _expectedData;
+
+        private readonly Stream _stream;
+
+        //private readonly ILightAttachment _lightAttachment;
+
+        private readonly AzureRedis _sut;
+
+        public AzureRedisTest()
+        {
+            Workbench.Instance.Reset();
+
+            Workbench.Instance.AddToCache(WorkbenchServiceType.Repository, _fakeLightCache);
+
+            _sut = new AzureRedis()
+            {
+
+            };
+
+            _expectedData = _fixture.Create<string>();
+            
+            //FALTA RESTO DA IMPLEMENTAÇÃO
+            
+            // _stream = ToMemoryStream(_expectedData);
+
+            //_lightAttachment = new LightAttachment
+            //{
+            //    ContentType = ContentType,
+            //    Id = _fixture.Create<string>() + ".txt",
+            //    MediaLink = _fixture.Create<string>(),
+            //    MediaStream = _stream,
+            //    Name = _fixture.Create<string>(),
+            //    ResourceId = _fixture.Create<string>(),
+            //};
+        }
+
+        [Fact]
+        public void CtorWorkingProprely()
+        {
+            ////Arrange
+            //var sut = new AzureRedis();
+            //var expected = new AzureRedis();
+            
+            ////Act
+            //var result = sut.
+            
+            ////Assert
+            //Assert.Equal(expected, _sut);
+        }
+
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Liquid.Runtime.Tests/Liquid.Runtime.Tests.csproj
+++ b/test/Liquid.Runtime.Tests/Liquid.Runtime.Tests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Liquid.OnAzure\Liquid.OnAzure.csproj" />
     <ProjectReference Include="..\..\src\Liquid.Runtime\Liquid.Runtime.csproj" />
   </ItemGroup>
 

--- a/test/Liquid.Runtime.Tests/MemoryCacheTest.cs
+++ b/test/Liquid.Runtime.Tests/MemoryCacheTest.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Liquid.Runtime.Tests
+{
+    class MemoryCacheTest
+    {
+    }
+}


### PR DESCRIPTION
LightClass is no longer used.
AzureRedis and MemoryCache now implements ILightCache directily.
The static methods from LightClass is now implemented in other class named CollectionTools
placed in Liquid.Runtime/Utils/CollectionTools.cs

Also, the files of unit test were created but without implemetations, yet.